### PR TITLE
v3.2.6 -- Fix Sbits for QC operations

### DIFF
--- a/doc/latex/address_table.tex
+++ b/doc/latex/address_table.tex
@@ -23,7 +23,7 @@
 
 \title{Optohybrid v3 Address Table}
 % START: ADDRESS_TABLE_VERSION :: DO NOT EDIT
-    \author{\textbf{GE1/1 Long} \\  \\ v03.02.05.1C \\ 20190711}
+    \author{\textbf{GE1/1 Short} \\  \\ v03.02.06.0C \\ 20190728}
 % END: ADDRESS_TABLE_VERSION :: DO NOT EDIT
 \begin{document}
 
@@ -804,6 +804,45 @@
     CLUSTER6 & \texttt{0x2097} & \texttt{[15:0]} & r & \texttt{} & Last cluster 6 \\\hline
     CLUSTER7 & \texttt{0x2098} & \texttt{[15:0]} & r & \texttt{} & Last cluster 7 \\\hline
     L1A\_DELAY & \texttt{0x20a0} & \texttt{[31:0]} & r & \texttt{} & Number of BX between this sbit and the subsequent L1A \\\hline
+    \end{tabularx}
+    \vspace{5mm}
+
+
+    \noindent
+    \subsection*{\textcolor{parentcolor}{\textbf{FPGA.TRIG.SBIT\_HITMAP}}}
+
+    \vspace{4mm}
+    \noindent
+    The Sbit hitmap module accumulates all incoming Sbits during a period of time
+    \noindent
+
+    \keepXColumns
+    \begin{tabularx}{\linewidth}{ | l | l | r | c | l | X | }
+    \hline
+    \textbf{Node} & \textbf{Adr} & \textbf{Bits} & \textbf{Dir} & \textbf{Def} & \textbf{Description} \\\hline
+    \nopagebreak
+    RESET & \texttt{0x20b0} & \texttt{[31:0]} & w & Pulsed & Reset the accumulation registers \\\hline
+    ACQUIRE & \texttt{0x20b1} & \texttt{[0:0]} & rw & \texttt{0x0} & Sbits are accumulated as long as this flag is set \\\hline
+    VFAT0\_MSB & \texttt{0x20b2} & \texttt{[31:0]} & r & \texttt{} & Accumulator for Sbit 63 to 32 of VFAT\{VFAT\_IDX\} \\\hline
+    VFAT0\_LSB & \texttt{0x20b3} & \texttt{[31:0]} & r & \texttt{} & Accumulator for Sbit 31 to 0 of VFAT\{VFAT\_IDX\} \\\hline
+    \end{tabularx}
+    \vspace{5mm}
+
+
+    \noindent
+    \subsection*{\textcolor{parentcolor}{\textbf{FPGA.TRIG.CTRL}}}
+
+    \vspace{4mm}
+    \noindent
+    Controls and monitors various parameters of the S-bit deserialization and cluster building.
+    \noindent
+
+    \keepXColumns
+    \begin{tabularx}{\linewidth}{ | l | l | r | c | l | X | }
+    \hline
+    \textbf{Node} & \textbf{Adr} & \textbf{Bits} & \textbf{Dir} & \textbf{Def} & \textbf{Description} \\\hline
+    \nopagebreak
+    SBIT\_SOT\_INVALID\_BITSKIP & \texttt{0x20e2} & \texttt{[23:0]} & r & \texttt{} & 24 bit list of VFATs with a invalid bitskip counter for Start-of-frame pulses \\\hline
     \end{tabularx}
     \vspace{5mm}
 

--- a/optohybrid_registers.xml
+++ b/optohybrid_registers.xml
@@ -382,7 +382,7 @@
         fw_reg_addr_msb="7"
         fw_reg_addr_lsb="0">
 
-            <node id="CTRL" address="0x0" description = "Controls and monitors various parameters of the S-bit deserialization and cluster building.">
+        <node id="CTRL" address="0x0" description = "Controls and monitors various parameters of the S-bit deserialization and cluster building.">
 
                 <!-- updated by update_vfat_counters.py-->
                 <!-- START: VFAT_MASK DO NOT EDIT -->
@@ -393,11 +393,11 @@
                 fw_default="0x0"/>
                 <!-- END: VFAT_MASK DO NOT EDIT -->
 
-                <node id="SBIT_DEADTIME" address="0x0" permission="rw"
-                    description="Set programmable oneshot deadtime which applies to retriggers on individual VFAT channels"
-                    fw_signal="trig_deadtime"
-                    mask="0x0f000000"
-                    fw_default="0x7"/>
+            <node id="SBIT_DEADTIME" address="0x0" permission="rw"
+                description="Set programmable oneshot deadtime which applies to retriggers on individual VFAT channels"
+                fw_signal="trig_deadtime"
+                mask="0x0f000000"
+                fw_default="0x7"/>
 
                 <!-- updated by update_vfat_counters.py-->
                 <!-- START: ACTIVE_VFATS DO NOT EDIT -->
@@ -407,16 +407,22 @@
                 fw_signal="active_vfats"/>
                 <!-- END: ACTIVE_VFATS DO NOT EDIT -->
 
-                <node id="CNT_OVERFLOW" address="0x2" permission="r"
-                    mask="0xffff"
-                    description="Overflow Counter (more than 8 clusters in a bx)"
-                    fw_cnt_en_signal="sbit_overflow"
-                    fw_cnt_reset_signal="cnt_reset"
-                    fw_cnt_snap_signal="cnt_snap"
-                    fw_signal="cnt_sbit_overflow"/>
+            <node id="CNT_OVERFLOW" address="0x2" permission="r"
+                mask="0xffff"
+                description="Overflow Counter (more than 8 clusters in a bx)"
+                fw_cnt_en_signal="sbit_overflow"
+                fw_cnt_reset_signal="cnt_reset"
+                fw_cnt_snap_signal="cnt_snap"
+                fw_signal="cnt_sbit_overflow"/>
+
+            <node id="ALIGNED_COUNT_TO_READY" address="0x2" permission="rw"
+                description="Number of link consecutive good frames required before the transmission unit is marked as good and S-bits can be produced"
+                fw_signal="aligned_count_to_ready"
+                mask="0xfff0000"
+                fw_default="0x1ff"/>
 
                 <!-- updated by update_vfat_counters.py-->
-                <!-- START: SOT_READY_UNSTABLE DO NOT EDIT -->
+                <!-- START: SOT_STATUS DO NOT EDIT -->
             <node id="SBIT_SOT_READY" address="0x3" permission="r"
                 description="24 bit list of VFATs with stable Start-of-frame pulses (in sync for a number of clock cycles)"
                 mask="0xffffff"
@@ -425,16 +431,14 @@
                 description="24 bit list of VFATs with unstable Start-of-frame pulses (became misaligned after already achieving lock)"
                 mask="0xffffff"
                 fw_signal="sot_unstable" />
-                <!-- END: SOT_READY_UNSTABLE DO NOT EDIT -->
+            <node id="SBIT_SOT_INVALID_BITSKIP" address="0xe2" permission="r"
+                description="24 bit list of VFATs with a invalid bitskip counter for Start-of-frame pulses"
+                mask="0xffffff"
+                fw_signal="sot_invalid_bitskip" />
+                <!-- END: SOT_STATUS DO NOT EDIT -->
 
 
-                <node id="ALIGNED_COUNT_TO_READY" address="0x2" permission="rw"
-                    description="Number of link consecutive good frames required before the transmission unit is marked as good and S-bits can be produced"
-                    fw_signal="aligned_count_to_ready"
-                    mask="0xfff0000"
-                    fw_default="0x1ff"/>
-
-                <node id="INVERT" address="0x5" description="Controls the polarity of S-bit signals to account for polarity swaps on the GEB or OH">
+	    <node id="INVERT" address="0x5" description="Controls the polarity of S-bit signals to account for polarity swaps on the GEB or OH">
                 <!-- START: INVERT_REGS DO NOT EDIT -->
                 <node id="SOT_INVERT" address="0x0" permission="rw"
                     description="1=invert pair"
@@ -1941,6 +1945,25 @@
                 <node id="L1A_DELAY" address="0x10" mask="0xffffffff" permission="r"
                     description="Number of BX between this sbit and the subsequent L1A"
                     fw_signal="sbitmon_l1a_delay"/>
+            </node>
+
+            <node id="SBIT_HITMAP" address="0xb0"
+                  description="The Sbit hitmap module accumulates all incoming Sbits during a period of time">
+                <node id="RESET" address="0x0" permission="w"
+                    description="Reset the accumulation registers"
+                    fw_write_pulse_signal="hitmap_reset"/>
+                <node id="ACQUIRE" address="0x1" mask="0x1" permission="rw"
+                    description="Sbits are accumulated as long as this flag is set"
+                    fw_signal="hitmap_acquire"
+                    fw_default="0x0"/>
+                <node id="VFAT${VFAT_IDX}_MSB" address="0x2" mask="0xffffffff" permission="r"
+                    description="Accumulator for Sbit 63 to 32 of VFAT{VFAT_IDX}"
+                    fw_signal="hitmap_sbits(${VFAT_IDX})(63 downto 32)"
+                    generate="true" generate_size="24" generate_address_step="0x2" generate_idx_var="VFAT_IDX"/>
+                <node id="VFAT${VFAT_IDX}_LSB" address="0x3" mask="0xffffffff" permission="r"
+                    description="Accumulator for Sbit 31 to 0 of VFAT{VFAT_IDX}"
+                    fw_signal="hitmap_sbits(${VFAT_IDX})(31 downto 0)"
+                    generate="true" generate_size="24" generate_address_step="0x2" generate_idx_var="VFAT_IDX"/>
             </node>
 
     </node> <!--TRIG-->

--- a/prj/OptoHybrid_v3.xise
+++ b/prj/OptoHybrid_v3.xise
@@ -16,8 +16,8 @@
 
   <files>
     <file xil_pn:name="../src/optohybrid_top.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="68"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="66"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="67"/>
     </file>
     <file xil_pn:name="../src/ucf/clocking.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
@@ -27,23 +27,23 @@
       <association xil_pn:name="Implementation" xil_pn:seqID="2"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/truncate_clusters.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="9"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="9"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/cluster_packer.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="35"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="35"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="36"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/consecutive_count.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="11"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="11"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/first8of1536.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="19"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="19"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/count_clusters.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="21"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="21"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/x_oneshot.v" xil_pn:type="FILE_VERILOG">
@@ -63,48 +63,48 @@
       <association xil_pn:name="Implementation" xil_pn:seqID="3"/>
     </file>
     <file xil_pn:name="../src/utils/clocking.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="62"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="60"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="61"/>
     </file>
     <file xil_pn:name="../src/utils/cylon.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="30"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="30"/>
     </file>
     <file xil_pn:name="../src/control/led_control.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="57"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="55"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="56"/>
     </file>
     <file xil_pn:name="../src/trigger/sbits.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="48"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="47"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="48"/>
     </file>
     <file xil_pn:name="../src/utils/sem_mon.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="45"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="44"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="45"/>
     </file>
     <file xil_pn:name="../src/wb/wb_switch.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="43"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="42"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="43"/>
     </file>
     <file xil_pn:name="../src/gbt/link_request.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="39"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="38"/>
-    </file>
-    <file xil_pn:name="../src/gbt/gbt_link.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="55"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="53"/>
-    </file>
-    <file xil_pn:name="../src/gbt/gbt_rx.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="41"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="40"/>
-    </file>
-    <file xil_pn:name="../src/gbt/gbt_tx.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="40"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="39"/>
     </file>
+    <file xil_pn:name="../src/gbt/gbt_link.vhd" xil_pn:type="FILE_VHDL">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="54"/>
+    </file>
+    <file xil_pn:name="../src/gbt/gbt_rx.vhd" xil_pn:type="FILE_VHDL">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="41"/>
+    </file>
+    <file xil_pn:name="../src/gbt/gbt_tx.vhd" xil_pn:type="FILE_VHDL">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="40"/>
+    </file>
     <file xil_pn:name="../src/trigger/trigger.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="63"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="61"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="62"/>
     </file>
     <file xil_pn:name="../src/trigger/trig_alignment/test/frame_aligner_tb.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
@@ -125,84 +125,84 @@
       <association xil_pn:name="PostTranslateSimulation" xil_pn:seqID="182"/>
     </file>
     <file xil_pn:name="../src/trigger/trig_alignment/frame_aligner.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="15"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="15"/>
     </file>
     <file xil_pn:name="../src/control/control.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="66"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="64"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="65"/>
     </file>
     <file xil_pn:name="../src/control/external.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="59"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="57"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="58"/>
     </file>
     <file xil_pn:name="../src/optohybrid_tb.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="71"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="PostMapSimulation" xil_pn:seqID="97"/>
       <association xil_pn:name="PostRouteSimulation" xil_pn:seqID="97"/>
       <association xil_pn:name="PostTranslateSimulation" xil_pn:seqID="97"/>
     </file>
     <file xil_pn:name="../src/control/reset.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="65"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="63"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="64"/>
     </file>
     <file xil_pn:name="../src/utils/err_indicator.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="29"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="29"/>
     </file>
     <file xil_pn:name="../src/utils/x_flashsm.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="25"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="25"/>
     </file>
     <file xil_pn:name="../src/gbt/gbt_serdes.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="54"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="52"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="53"/>
     </file>
     <file xil_pn:name="../src/gbt/gbt.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="64"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="62"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="63"/>
     </file>
     <file xil_pn:name="../src/control/ttc.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="56"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="54"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="55"/>
     </file>
     <file xil_pn:name="../src/control/fmm.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="58"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="56"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="57"/>
     </file>
     <file xil_pn:name="../src/ucf/gbt.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/control/adc.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="67"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="65"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="66"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/priority768.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="10"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="10"/>
     </file>
     <file xil_pn:name="../src/wb/ipb_switch.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="61"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="59"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="60"/>
     </file>
     <file xil_pn:name="../src/wb/ipbus_slave.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="44"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="43"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="44"/>
     </file>
     <file xil_pn:name="../src/utils/synchronizer.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="26"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="26"/>
     </file>
     <file xil_pn:name="../src/pkg/ipbus_pkg.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="22"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="22"/>
     </file>
     <file xil_pn:name="../src/pkg/registers.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="50"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="49"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="50"/>
     </file>
     <file xil_pn:name="../src/trigger/trig_alignment/trig_alignment.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="31"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="31"/>
     </file>
     <file xil_pn:name="../src/trigger/trig_alignment/trig_pkg.vhd" xil_pn:type="FILE_VHDL">
@@ -210,19 +210,19 @@
       <association xil_pn:name="Implementation" xil_pn:seqID="1"/>
     </file>
     <file xil_pn:name="../src/gbt/to_gbt_ser.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="38"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="37"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="38"/>
     </file>
     <file xil_pn:name="../src/utils/counter_snap.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="46"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="45"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="46"/>
     </file>
     <file xil_pn:name="../src/utils/progress_bar.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="27"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="27"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/lac.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="18"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="18"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/encoder_mux.v" xil_pn:type="FILE_VERILOG">
@@ -234,39 +234,39 @@
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/trigger/channel_to_strip.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="33"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="33"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="34"/>
     </file>
     <file xil_pn:name="../src/control/device_dna.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="60"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="58"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="59"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/merge16_light.v" xil_pn:type="FILE_VERILOG">
       <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/utils/6b8b.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="14"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="14"/>
     </file>
     <file xil_pn:name="../src/utils/6b8b_pkg.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="8"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="8"/>
     </file>
     <file xil_pn:name="../src/utils/8b6b.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="13"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="13"/>
     </file>
     <file xil_pn:name="../src/gbt/test/link_oh_fpga_rx.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="70"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/gbt/test/link_oh_fpga_tx.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="69"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/utils/bitslip.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="7"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="7"/>
     </file>
     <file xil_pn:name="../src/utils/DRU.vhd" xil_pn:type="FILE_VHDL">
@@ -274,7 +274,7 @@
       <association xil_pn:name="Implementation" xil_pn:seqID="6"/>
     </file>
     <file xil_pn:name="../src/utils/OVERSAMPLE.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="12"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="7"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="12"/>
     </file>
     <file xil_pn:name="../src/utils/iodelay.vhd" xil_pn:type="FILE_VHDL">
@@ -289,95 +289,112 @@
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/control/startup.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="42"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="41"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="42"/>
     </file>
     <file xil_pn:name="../src/sbit_cluster_packer/source/find_cluster_primaries.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="20"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="20"/>
     </file>
     <file xil_pn:name="../src/trigger/active_vfats.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="34"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="34"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="35"/>
     </file>
     <file xil_pn:name="../src/ucf/sbits.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/utils/fader.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="28"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="28"/>
     </file>
     <file xil_pn:name="../src/ucf/misc_v3b.ucf" xil_pn:type="FILE_UCF">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/trigger/sbit_monitor.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="47"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="46"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="47"/>
     </file>
     <file xil_pn:name="../src/trigger/link/gem_data_out.v" xil_pn:type="FILE_VERILOG">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="49"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="48"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="49"/>
     </file>
     <file xil_pn:name="../src/trigger/link/v6_gtx_wrapper.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="32"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="32"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="33"/>
     </file>
     <file xil_pn:name="../src/trigger/link/gtx_wizard_4output_v6_tx_sync.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="16"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="16"/>
     </file>
     <file xil_pn:name="../src/trigger/link/gtx_wizard_4output_v6_gtx_manual.vhd" xil_pn:type="FILE_VHDL">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="17"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="17"/>
     </file>
-    <file xil_pn:name="../src/ip_cores/xadc.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="99"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="50"/>
-    </file>
-    <file xil_pn:name="../src/ip_cores/fifo_8b.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="117"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
-    </file>
-    <file xil_pn:name="../src/ip_cores/gbt_clocking.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="128"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    <file xil_pn:name="../src/trigger/sbits_hitmap.vhd" xil_pn:type="FILE_VHDL">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="32"/>
     </file>
     <file xil_pn:name="../src/ip_cores/logic_clocking.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="135"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="51"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="52"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/fifo_8b.xco" xil_pn:type="FILE_COREGEN">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_request_rx.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="151"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="24"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_request_tx.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="155"/>
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="23"/>
     </file>
-    <file xil_pn:name="../src/ip_cores/sem.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="166"/>
-      <association xil_pn:name="Implementation" xil_pn:seqID="36"/>
-    </file>
-    <file xil_pn:name="../src/ip_cores/gtx_wizard_4output_v6.xco" xil_pn:type="FILE_COREGEN">
-      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="186"/>
+    <file xil_pn:name="../src/ip_cores/gbt_cdc_fifo.xco" xil_pn:type="FILE_COREGEN">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
-    <file xil_pn:name="../src/ip_cores/xadc.xise" xil_pn:type="FILE_COREGENISE">
+    <file xil_pn:name="../src/ip_cores/gbt_clocking.xco" xil_pn:type="FILE_COREGEN">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/gtx_wizard_4output_v6.xco" xil_pn:type="FILE_COREGEN">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/sem.xco" xil_pn:type="FILE_COREGEN">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="37"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/xadc.xco" xil_pn:type="FILE_COREGEN">
+      <association xil_pn:name="BehavioralSimulation" xil_pn:seqID="0"/>
+      <association xil_pn:name="Implementation" xil_pn:seqID="51"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/logic_clocking.xise" xil_pn:type="FILE_COREGENISE">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_8b.xise" xil_pn:type="FILE_COREGENISE">
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
-    </file>
-    <file xil_pn:name="../src/ip_cores/gbt_clocking.xise" xil_pn:type="FILE_COREGENISE">
-      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
-    </file>
-    <file xil_pn:name="../src/ip_cores/logic_clocking.xise" xil_pn:type="FILE_COREGENISE">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_request_rx.xise" xil_pn:type="FILE_COREGENISE">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
     <file xil_pn:name="../src/ip_cores/fifo_request_tx.xise" xil_pn:type="FILE_COREGENISE">
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/gbt_cdc_fifo.xise" xil_pn:type="FILE_COREGENISE">
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/gbt_clocking.xise" xil_pn:type="FILE_COREGENISE">
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/gtx_wizard_4output_v6.xise" xil_pn:type="FILE_COREGENISE">
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/sem.xise" xil_pn:type="FILE_COREGENISE">
+      <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
+    </file>
+    <file xil_pn:name="../src/ip_cores/xadc.xise" xil_pn:type="FILE_COREGENISE">
       <association xil_pn:name="Implementation" xil_pn:seqID="0"/>
     </file>
   </files>
@@ -414,6 +431,7 @@
     <property xil_pn:name="Compile XilinxCoreLib (CORE Generator) Simulation Library" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Compile for HDL Debugging" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Configuration Clk (Configuration Pins)" xil_pn:value="Pull Up" xil_pn:valueState="default"/>
+    <property xil_pn:name="Configuration Name" xil_pn:value="Default" xil_pn:valueState="default"/>
     <property xil_pn:name="Configuration Pin Busy" xil_pn:value="Pull Up" xil_pn:valueState="default"/>
     <property xil_pn:name="Configuration Pin CS" xil_pn:value="Pull Up" xil_pn:valueState="default"/>
     <property xil_pn:name="Configuration Pin DIn" xil_pn:value="Pull Up" xil_pn:valueState="default"/>
@@ -440,7 +458,9 @@
     <property xil_pn:name="Cycles for First BPI Page Read" xil_pn:value="1" xil_pn:valueState="default"/>
     <property xil_pn:name="DCI Update Mode" xil_pn:value="As Required" xil_pn:valueState="non-default"/>
     <property xil_pn:name="DSP Utilization Ratio" xil_pn:value="100" xil_pn:valueState="default"/>
+    <property xil_pn:name="Data Flow window" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Delay Values To Be Read from SDF" xil_pn:value="Setup Time" xil_pn:valueState="default"/>
+    <property xil_pn:name="Delay Values To Be Read from SDF ModelSim" xil_pn:value="Setup Time" xil_pn:valueState="default"/>
     <property xil_pn:name="Device" xil_pn:value="xc6vlx130t" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Device Family" xil_pn:value="Virtex6" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Device Speed Grade/Select ABS Minimum" xil_pn:value="-1" xil_pn:valueState="default"/>
@@ -479,7 +499,7 @@
     <property xil_pn:name="Functional Model Target Language Coregen" xil_pn:value="VHDL" xil_pn:valueState="default"/>
     <property xil_pn:name="Functional Model Target Language Schematic" xil_pn:value="VHDL" xil_pn:valueState="default"/>
     <property xil_pn:name="Generate Architecture Only (No Entity Declaration)" xil_pn:value="false" xil_pn:valueState="default"/>
-    <property xil_pn:name="Generate Asynchronous Delay Report" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Generate Asynchronous Delay Report" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Generate Clock Region Report" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Generate Constraints Interaction Report" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Generate Constraints Interaction Report Post Trace" xil_pn:value="true" xil_pn:valueState="non-default"/>
@@ -490,10 +510,12 @@
     <property xil_pn:name="Generate Post-Place &amp; Route Power Report" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Generate Post-Place &amp; Route Simulation Model" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Generate RTL Schematic" xil_pn:value="Yes" xil_pn:valueState="default"/>
+    <property xil_pn:name="Generate SAIF File for Power Optimization/Estimation" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Generate SAIF File for Power Optimization/Estimation Par" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Generate Testbench File" xil_pn:value="false" xil_pn:valueState="default"/>
-    <property xil_pn:name="Generate Timegroups Section" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Generate Timegroups Section" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Generate Timegroups Section Post Trace" xil_pn:value="true" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Generate Verbose Library Compilation Messages" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Generics, Parameters" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Global Optimization Goal" xil_pn:value="AllClockNets" xil_pn:valueState="default"/>
     <property xil_pn:name="Global Optimization map virtex5" xil_pn:value="Speed" xil_pn:valueState="non-default"/>
@@ -503,8 +525,10 @@
     <property xil_pn:name="HMAC Key (Hex String)" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Hierarchy Separator" xil_pn:value="/" xil_pn:valueState="default"/>
     <property xil_pn:name="ISim UUT Instance Name" xil_pn:value="srp" xil_pn:valueState="default"/>
+    <property xil_pn:name="Ignore Pre-Compiled Library Warning Check" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Ignore User Timing Constraints Map" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Ignore User Timing Constraints Par" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Ignore Version Check" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Implementation Top" xil_pn:value="Architecture|optohybrid_top|Behavioral" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Implementation Top File" xil_pn:value="../src/optohybrid_top.vhd" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Implementation Top Instance Path" xil_pn:value="/optohybrid_top" xil_pn:valueState="non-default"/>
@@ -526,17 +550,24 @@
     <property xil_pn:name="Language" xil_pn:value="VHDL" xil_pn:valueState="default"/>
     <property xil_pn:name="Last Applied Goal" xil_pn:value="Optohybrid" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Last Applied Strategy" xil_pn:value="Performance with IOB Packing;/media/psf/Dropbox/CMS/Firmware/OptoHybridv3/prj/Optohybrid strategy.xds" xil_pn:valueState="non-default"/>
-    <property xil_pn:name="Last Selected UCF File" xil_pn:value="" xil_pn:valueState="default"/>
+    <property xil_pn:name="Last Selected UCF File" xil_pn:value="/home/lpetre/Documents/OptoHybridv3-devel/src/ucf/misc_v3b.ucf" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Last Unlock Status" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Launch SDK after Export" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Library for Verilog Sources" xil_pn:value="" xil_pn:valueState="default"/>
+    <property xil_pn:name="List window" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Load glbl" xil_pn:value="true" xil_pn:valueState="default"/>
+    <property xil_pn:name="Log All Signals In Behavioral Simulation" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Log All Signals In Post-Map Simulation" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Log All Signals In Post-Par Simulation" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Log All Signals In Post-Translate Simulation" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Manual Implementation Compile Order" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Map Slice Logic into Unused Block RAMs" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Max Fanout" xil_pn:value="10000" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Maximum Compression" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Maximum Number of Lines in Report" xil_pn:value="1000" xil_pn:valueState="default"/>
     <property xil_pn:name="Maximum Signal Name Length" xil_pn:value="20" xil_pn:valueState="default"/>
+    <property xil_pn:name="ModelSim Post-Map UUT Instance Name" xil_pn:value="srp" xil_pn:valueState="default"/>
+    <property xil_pn:name="ModelSim Post-Par UUT Instance Name" xil_pn:value="srp" xil_pn:valueState="default"/>
     <property xil_pn:name="Move First Flip-Flop Stage" xil_pn:value="false" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Move Last Flip-Flop Stage" xil_pn:value="false" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Netlist Hierarchy" xil_pn:value="As Optimized" xil_pn:valueState="default"/>
@@ -561,6 +592,9 @@
     <property xil_pn:name="Other Simulator Commands Post-Map" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Other Simulator Commands Post-Route" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Other Simulator Commands Post-Translate" xil_pn:value="" xil_pn:valueState="default"/>
+    <property xil_pn:name="Other VCOM Command Line Options" xil_pn:value="" xil_pn:valueState="default"/>
+    <property xil_pn:name="Other VLOG Command Line Options" xil_pn:value="" xil_pn:valueState="default"/>
+    <property xil_pn:name="Other VSIM Command Line Options" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Other XPWR Command Line Options" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Other XST Command Line Options" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Output Extended Identifiers" xil_pn:value="false" xil_pn:valueState="default"/>
@@ -570,7 +604,7 @@
     <property xil_pn:name="Pack I/O Registers/Latches into IOBs" xil_pn:value="For Inputs and Outputs" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Package" xil_pn:value="ff1156" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Perform Advanced Analysis" xil_pn:value="false" xil_pn:valueState="default"/>
-    <property xil_pn:name="Perform Advanced Analysis Post Trace" xil_pn:value="true" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Perform Advanced Analysis Post Trace" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Perform Timing-Driven Packing and Placement" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Place &amp; Route Effort Level (Overall)" xil_pn:value="Standard" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Place And Route Mode" xil_pn:value="Route Only" xil_pn:valueState="default"/>
@@ -586,6 +620,7 @@
     <property xil_pn:name="Power Reduction Par" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Power Reduction Xst" xil_pn:value="true" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Preferred Language" xil_pn:value="VHDL" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Process window" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Produce Verbose Report" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Project Description" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Project Generator" xil_pn:value="ProjNav" xil_pn:valueState="default"/>
@@ -626,8 +661,8 @@
     <property xil_pn:name="Run for Specified Time Translate" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Safe Implementation" xil_pn:value="Yes" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Security" xil_pn:value="Enable Readback and Reconfiguration" xil_pn:valueState="default"/>
-    <property xil_pn:name="Selected Module Instance Name" xil_pn:value="/optohybrid_top_tb" xil_pn:valueState="non-default"/>
-    <property xil_pn:name="Selected Simulation Root Source Node Behavioral" xil_pn:value="work.optohybrid_top_tb" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Selected Module Instance Name" xil_pn:value="/TRG_TX_BUF_BYPASS_GTX" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Selected Simulation Root Source Node Behavioral" xil_pn:value="work.TRG_TX_BUF_BYPASS_GTX" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Selected Simulation Root Source Node Post-Map" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Selected Simulation Root Source Node Post-Route" xil_pn:value="work.optohybrid_top_tb" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Selected Simulation Root Source Node Post-Translate" xil_pn:value="" xil_pn:valueState="default"/>
@@ -635,21 +670,27 @@
     <property xil_pn:name="Shift Register Extraction" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Shift Register Minimum Size virtex6" xil_pn:value="2" xil_pn:valueState="default"/>
     <property xil_pn:name="Show All Models" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Signal window" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Simulation Model Target" xil_pn:value="VHDL" xil_pn:valueState="default"/>
+    <property xil_pn:name="Simulation Resolution" xil_pn:value="Default (1 ps)" xil_pn:valueState="default"/>
     <property xil_pn:name="Simulation Run Time ISim" xil_pn:value="25us" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Simulation Run Time Map" xil_pn:value="1000 ns" xil_pn:valueState="default"/>
+    <property xil_pn:name="Simulation Run Time Modelsim" xil_pn:value="1000ns" xil_pn:valueState="default"/>
     <property xil_pn:name="Simulation Run Time Par" xil_pn:value="1000 ns" xil_pn:valueState="default"/>
     <property xil_pn:name="Simulation Run Time Translate" xil_pn:value="1000 ns" xil_pn:valueState="default"/>
     <property xil_pn:name="Simulator" xil_pn:value="ISim (VHDL/Verilog)" xil_pn:valueState="default"/>
     <property xil_pn:name="Slice Utilization Ratio" xil_pn:value="100" xil_pn:valueState="default"/>
+    <property xil_pn:name="Source window" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify 'define Macro Name and Value" xil_pn:value="" xil_pn:valueState="default"/>
-    <property xil_pn:name="Specify Top Level Instance Names Behavioral" xil_pn:value="work.optohybrid_top_tb" xil_pn:valueState="default"/>
+    <property xil_pn:name="Specify Top Level Instance Names" xil_pn:value="" xil_pn:valueState="default"/>
+    <property xil_pn:name="Specify Top Level Instance Names Behavioral" xil_pn:value="work.TRG_TX_BUF_BYPASS_GTX" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify Top Level Instance Names Post-Map" xil_pn:value="Default" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify Top Level Instance Names Post-Route" xil_pn:value="work.optohybrid_top_tb" xil_pn:valueState="default"/>
     <property xil_pn:name="Specify Top Level Instance Names Post-Translate" xil_pn:value="Default" xil_pn:valueState="default"/>
     <property xil_pn:name="Speed Grade" xil_pn:value="-1" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Starting Address for Fallback Configuration virtex6" xil_pn:value="None" xil_pn:valueState="default"/>
     <property xil_pn:name="Starting Placer Cost Table (1-100)" xil_pn:value="28" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="Structure window" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Synthesis Tool" xil_pn:value="XST (VHDL/Verilog)" xil_pn:valueState="default"/>
     <property xil_pn:name="Target Simulator" xil_pn:value="Please Specify" xil_pn:valueState="default"/>
     <property xil_pn:name="Timing Mode Map" xil_pn:value="Performance Evaluation" xil_pn:valueState="default"/>
@@ -660,7 +701,13 @@
     <property xil_pn:name="Tristate On Configuration Pulse Width" xil_pn:value="0" xil_pn:valueState="default"/>
     <property xil_pn:name="Unused IOB Pins" xil_pn:value="Pull Down" xil_pn:valueState="default"/>
     <property xil_pn:name="Use 64-bit PlanAhead on 64-bit Systems" xil_pn:value="true" xil_pn:valueState="default"/>
+    <property xil_pn:name="Use Automatic Do File" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Use Clock Enable" xil_pn:value="Auto" xil_pn:valueState="default"/>
+    <property xil_pn:name="Use Configuration Name" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Use Custom Do File Behavioral" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Use Custom Do File Map" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Use Custom Do File Par" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Use Custom Do File Translate" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Use Custom Project File Behavioral" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Use Custom Project File Post-Map" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Use Custom Project File Post-Route" xil_pn:value="false" xil_pn:valueState="default"/>
@@ -674,6 +721,7 @@
     <property xil_pn:name="Use Custom Waveform Configuration File Par" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Use Custom Waveform Configuration File Translate" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Use DSP Block" xil_pn:value="Auto" xil_pn:valueState="default"/>
+    <property xil_pn:name="Use Explicit Declarations Only" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Use LOC Constraints" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Use RLOC Constraints" xil_pn:value="Yes" xil_pn:valueState="default"/>
     <property xil_pn:name="Use Smart Guide" xil_pn:value="false" xil_pn:valueState="default"/>
@@ -684,19 +732,22 @@
     <property xil_pn:name="User Browsed Strategy Files" xil_pn:value="/media/psf/Dropbox/CMS/Firmware/OptoHybridv3/prj/Optohybrid strategy.xds" xil_pn:valueState="non-default"/>
     <property xil_pn:name="UserID Code (8 Digit Hexadecimal)" xil_pn:value="0xFFFFFFFF" xil_pn:valueState="default"/>
     <property xil_pn:name="VHDL Source Analysis Standard" xil_pn:value="VHDL-200X" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="VHDL Syntax" xil_pn:value="93" xil_pn:valueState="default"/>
     <property xil_pn:name="Value Range Check" xil_pn:value="false" xil_pn:valueState="default"/>
+    <property xil_pn:name="Variables window" xil_pn:value="false" xil_pn:valueState="default"/>
     <property xil_pn:name="Verilog Macros" xil_pn:value="" xil_pn:valueState="default"/>
     <property xil_pn:name="Wait for DCI Match (Output Events) virtex5" xil_pn:value="Auto" xil_pn:valueState="default"/>
     <property xil_pn:name="Wait for PLL Lock (Output Events) virtex6" xil_pn:value="No Wait" xil_pn:valueState="default"/>
     <property xil_pn:name="Watchdog Timer Mode virtex5" xil_pn:value="Off" xil_pn:valueState="default"/>
     <property xil_pn:name="Watchdog Timer Value virtex5" xil_pn:value="0x000000" xil_pn:valueState="default"/>
+    <property xil_pn:name="Wave window" xil_pn:value="true" xil_pn:valueState="default"/>
     <property xil_pn:name="Work Directory" xil_pn:value="" xil_pn:valueState="non-default"/>
     <property xil_pn:name="Working Directory" xil_pn:value="." xil_pn:valueState="non-default"/>
     <property xil_pn:name="Write Timing Constraints" xil_pn:value="false" xil_pn:valueState="default"/>
     <!--                                                                                  -->
     <!-- The following properties are for internal use only. These should not be modified.-->
     <!--                                                                                  -->
-    <property xil_pn:name="PROP_BehavioralSimTop" xil_pn:value="Module|optohybrid_top_tb" xil_pn:valueState="non-default"/>
+    <property xil_pn:name="PROP_BehavioralSimTop" xil_pn:value="Architecture|oversample_tb|behavior" xil_pn:valueState="non-default"/>
     <property xil_pn:name="PROP_DesignName" xil_pn:value="OH_v2" xil_pn:valueState="non-default"/>
     <property xil_pn:name="PROP_DevFamilyPMName" xil_pn:value="virtex6" xil_pn:valueState="default"/>
     <property xil_pn:name="PROP_FPGAConfiguration" xil_pn:value="FPGAConfiguration" xil_pn:valueState="default"/>

--- a/src/gbt/gbt.vhd
+++ b/src/gbt/gbt.vhd
@@ -34,7 +34,6 @@ port(
     clock_i            : in std_logic; -- 40 MHz logic clock
 
     gbt_clk40          : in std_logic; -- 40  MHz phase shiftable frame clock from GBT
-    gbt_clk80          : in std_logic; -- 40  MHz phase shiftable frame clock from GBT
     gbt_clk160_0       : in std_logic; -- 320 MHz phase shiftable frame clock from GBT
     gbt_clk160_90      : in std_logic; -- 320 MHz phase shiftable frame clock from GBT
 
@@ -152,7 +151,6 @@ begin
        -- input clocks
 
        clk_1x           => gbt_clk40,      -- 40 MHz phase shiftable frame clock from GBT
-       clk_2x           => gbt_clk80,      -- 80 MHz phase shiftable frame clock from GBT
        clk_4x           => gbt_clk160_0,   --
        clk_4x_90        => gbt_clk160_90,  --
 

--- a/src/gbt/gbt_serdes.vhd
+++ b/src/gbt/gbt_serdes.vhd
@@ -39,9 +39,8 @@ port(
     -- input clocks
 
     clk_1x      : in std_logic; -- 40 MHz phase shiftable frame clock from GBT
-    clk_2x      : in std_logic; -- 160 MHz phase shiftable frame clock from GBT
-    clk_4x   : in std_logic; -- 160 MHz phase shiftable frame clock from GBT
-    clk_4x_90  : in std_logic; -- 160 MHz phase shiftable frame clock from GBT
+    clk_4x      : in std_logic; -- 160 MHz phase shiftable frame clock from GBT
+    clk_4x_90   : in std_logic; -- 160 MHz phase shiftable frame clock from GBT
 
     -- serial data to/from GBTx
     elink_o_p        : out std_logic;
@@ -120,20 +119,21 @@ begin
         g_PHASE_SEL_EXTERNAL => FALSE
     )
     port map (
-        rst           => rst,
-        invert        => '0',
-        rxd_p         => elink_i_p,
-        rxd_n         => elink_i_n,
-        clk1x_logic   => clk_2x,
-        clk2x_logic   => clk_4x,
-        clk2x_0       => clk_4x,
-        clk2x_90      => clk_4x_90,
-        clk2x_180     => not clk_4x,
-        rxdata_o      => from_gbt_raw,
-        tap_delay_i   => (others => '0'),
-        phase_sel_in  => (others => '0'),
-        e4_out        => sump_vector (3 downto 0),
-        phase_sel_out => sump_vector (5 downto 4)
+        clk1x_logic       => clk_1x,
+        clk1x             => clk_1x,
+        clk4x_0           => clk_4x,
+        clk4x_90          => clk_4x_90,
+        reset_i           => rst,
+        rxd_p             => elink_i_p,
+        rxd_n             => elink_i_n,
+        rxdata_o          => from_gbt_raw,
+        invert            => '0',
+        tap_delay_i       => (others => '0'),
+        e4_in             => (others => '0'),
+        e4_out            => sump_vector (3 downto 0),
+        phase_sel_in      => (others => '0'),
+        phase_sel_out     => sump_vector (5 downto 4),
+        invalid_bitskip_o => open
     );
 
     --------------------------------------------------------------------------------------------------------------------

--- a/src/ip_cores/logic_clocking.xco
+++ b/src/ip_cores/logic_clocking.xco
@@ -1,7 +1,7 @@
 ##############################################################
 #
 # Xilinx Core Generator version 14.7
-# Date: Wed Jun 19 21:54:01 2019
+# Date: Fri Jul 19 07:23:19 2019
 #
 ##############################################################
 #
@@ -64,32 +64,32 @@ CSET clkfb_out_n_port=CLKFB_OUT_N
 CSET clkfb_out_p_port=CLKFB_OUT_P
 CSET clkfb_out_port=CLKFB_OUT
 CSET clkfb_stopped_port=CLKFB_STOPPED
-CSET clkin1_jitter_ps=6.248
+CSET clkin1_jitter_ps=6.18
 CSET clkin1_ui_jitter=0.002
 CSET clkin2_jitter_ps=100.0
 CSET clkin2_ui_jitter=0.010
 CSET clkout1_drives=BUFG
 CSET clkout1_requested_duty_cycle=50.000
-CSET clkout1_requested_out_freq=40
+CSET clkout1_requested_out_freq=40.453
 CSET clkout1_requested_phase=0.000
 CSET clkout2_drives=BUFG
 CSET clkout2_requested_duty_cycle=50.000
-CSET clkout2_requested_out_freq=80
+CSET clkout2_requested_out_freq=80.906
 CSET clkout2_requested_phase=0.000
 CSET clkout2_used=true
 CSET clkout3_drives=BUFG
 CSET clkout3_requested_duty_cycle=50.000
-CSET clkout3_requested_out_freq=160
+CSET clkout3_requested_out_freq=160.812
 CSET clkout3_requested_phase=0.000
 CSET clkout3_used=true
 CSET clkout4_drives=BUFG
 CSET clkout4_requested_duty_cycle=50.000
-CSET clkout4_requested_out_freq=160
+CSET clkout4_requested_out_freq=160.812
 CSET clkout4_requested_phase=90
 CSET clkout4_used=true
 CSET clkout5_drives=BUFG
 CSET clkout5_requested_duty_cycle=50.000
-CSET clkout5_requested_out_freq=200
+CSET clkout5_requested_out_freq=202.265
 CSET clkout5_requested_phase=0
 CSET clkout5_used=true
 CSET clkout6_drives=BUFG
@@ -151,7 +151,7 @@ CSET mmcm_bandwidth=LOW
 CSET mmcm_clkfbout_mult_f=5.000
 CSET mmcm_clkfbout_phase=0.000
 CSET mmcm_clkfbout_use_fine_ps=false
-CSET mmcm_clkin1_period=3.124
+CSET mmcm_clkin1_period=3.090
 CSET mmcm_clkin2_period=10.0
 CSET mmcm_clkout0_divide_f=20.000
 CSET mmcm_clkout0_duty_cycle=0.5
@@ -223,7 +223,7 @@ CSET pll_divclk_divide=1
 CSET pll_notes=None
 CSET pll_ref_jitter=0.010
 CSET power_down_port=POWER_DOWN
-CSET prim_in_freq=320.08
+CSET prim_in_freq=323.620
 CSET prim_in_jitter=0.002
 CSET prim_source=No_buffer
 CSET primary_port=clk_in1
@@ -266,4 +266,4 @@ CSET use_status=false
 MISC pkg_timestamp=2012-05-10T12:44:55Z
 # END Extra information
 GENERATE
-# CRC: ec738f57
+# CRC: daa15b7b

--- a/src/optohybrid_top.vhd
+++ b/src/optohybrid_top.vhd
@@ -104,7 +104,6 @@ architecture Behavioral of optohybrid_top is
     signal eprt_mmcm_locked : std_logic;
 
     signal clk40      : std_logic;
-    signal clk80      : std_logic;
     signal clk160_0   : std_logic;
     signal clk160_90  : std_logic;
     signal clk200     : std_logic;
@@ -213,7 +212,7 @@ begin
         mmcm_locked_o       => mmcm_locked,
 
         clk40_o          => clk40,      -- 40  MHz e-port aligned GBT clock
-        clk80_o          => clk80,      -- 80  MHz e-port aligned GBT clock
+        clk80_o          => open,       -- 80  MHz e-port aligned GBT clock
         clk160_0_o       => clk160_0,   -- 160  MHz e-port aligned GBT clock
         clk160_90_o      => clk160_90,  -- 160  MHz e-port aligned GBT clock
         clk200_o         => clk200      -- 200  MHz e-port aligned GBT clock
@@ -222,7 +221,7 @@ begin
     reset_ctl : entity work.reset
     port map (
         clock_i        => clk40,
-        soft_reset     => soft_reset or (not mgts_ready),
+        soft_reset     => soft_reset,
         mmcms_locked_i => mmcm_locked,
         gbt_rxready_i  => gbt_rxready(0),
         gbt_rxvalid_i  => gbt_rxvalid(0),
@@ -251,7 +250,6 @@ begin
         -- input clocks
 
         gbt_clk40      => clk40,     -- 40 MHz frame clock
-        gbt_clk80      => clk80,     -- 80  MHz e-port aligned GBT clock
         gbt_clk160_0   => clk160_0,  --
         gbt_clk160_90  => clk160_90, --
 
@@ -438,14 +436,13 @@ begin
         logic_mmcm_lock_i => logic_mmcm_locked,
         logic_mmcm_reset_o => logic_mmcm_reset,
 
-        clk_40_sbit     => clk40,
-        clk_80_sbit     => clk80,
-        clk_160_sbit    => clk160_0,
-        clk_200_sbit    => clk200,
-        clk_160_90_sbit => clk160_90,
-
         clk_40      => clk40,
         clk_160     => clk160_0,
+
+        clk_40_sbit     => clk40,
+        clk_160_sbit    => clk160_0,
+        clk_160_90_sbit => clk160_90,
+        clk_200_sbit    => clk200,
 
         -- mgt pairs
         mgt_tx_p => mgt_tx_p_o,

--- a/src/pkg/param_pkg.vhd
+++ b/src/pkg/param_pkg.vhd
@@ -7,13 +7,13 @@ package param_pkg is
     -- START: PARAM_PKG DO NOT EDIT --
     constant MAJOR_VERSION          : std_logic_vector(7 downto 0) := x"03";
     constant MINOR_VERSION          : std_logic_vector(7 downto 0) := x"02";
-    constant RELEASE_VERSION        : std_logic_vector(7 downto 0) := x"05";
+    constant RELEASE_VERSION        : std_logic_vector(7 downto 0) := x"06";
 
     constant RELEASE_YEAR           : std_logic_vector(15 downto 0) := x"2019";
     constant RELEASE_MONTH          : std_logic_vector(7 downto  0) := x"07";
-    constant RELEASE_DAY            : std_logic_vector(7 downto  0) := x"11";
+    constant RELEASE_DAY            : std_logic_vector(7 downto  0) := x"28";
 
-    constant RELEASE_HARDWARE       : std_logic_vector(7 downto  0) := x"1C";
+    constant RELEASE_HARDWARE       : std_logic_vector(7 downto  0) := x"0C";
 
     constant FPGA_TYPE     : string  := "VIRTEX6";
     constant FPGA_TYPE_IS_VIRTEX6  : integer := 1;

--- a/src/pkg/registers.vhd
+++ b/src/pkg/registers.vhd
@@ -258,7 +258,7 @@ package registers is
     -- Connects to the trigger control module
     --============================================================================
 
-    constant REG_TRIG_NUM_REGS : integer := 121;
+    constant REG_TRIG_NUM_REGS : integer := 172;
     constant REG_TRIG_ADDRESS_MSB : integer := 7;
     constant REG_TRIG_ADDRESS_LSB : integer := 0;
     constant REG_TRIG_CTRL_VFAT_MASK_ADDR    : std_logic_vector(7 downto 0) := x"00";
@@ -1929,6 +1929,210 @@ package registers is
     constant REG_TRIG_SBIT_MONITOR_L1A_DELAY_ADDR    : std_logic_vector(7 downto 0) := x"a0";
     constant REG_TRIG_SBIT_MONITOR_L1A_DELAY_MSB    : integer := 31;
     constant REG_TRIG_SBIT_MONITOR_L1A_DELAY_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_RESET_ADDR    : std_logic_vector(7 downto 0) := x"b0";
+    constant REG_TRIG_SBIT_HITMAP_RESET_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_RESET_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_ACQUIRE_ADDR    : std_logic_vector(7 downto 0) := x"b1";
+    constant REG_TRIG_SBIT_HITMAP_ACQUIRE_BIT    : integer := 0;
+    constant REG_TRIG_SBIT_HITMAP_ACQUIRE_DEFAULT : std_logic := '0';
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT0_MSB_ADDR    : std_logic_vector(7 downto 0) := x"b2";
+    constant REG_TRIG_SBIT_HITMAP_VFAT0_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT0_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT0_LSB_ADDR    : std_logic_vector(7 downto 0) := x"b3";
+    constant REG_TRIG_SBIT_HITMAP_VFAT0_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT0_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT1_MSB_ADDR    : std_logic_vector(7 downto 0) := x"b4";
+    constant REG_TRIG_SBIT_HITMAP_VFAT1_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT1_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT1_LSB_ADDR    : std_logic_vector(7 downto 0) := x"b5";
+    constant REG_TRIG_SBIT_HITMAP_VFAT1_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT1_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT2_MSB_ADDR    : std_logic_vector(7 downto 0) := x"b6";
+    constant REG_TRIG_SBIT_HITMAP_VFAT2_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT2_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT2_LSB_ADDR    : std_logic_vector(7 downto 0) := x"b7";
+    constant REG_TRIG_SBIT_HITMAP_VFAT2_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT2_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT3_MSB_ADDR    : std_logic_vector(7 downto 0) := x"b8";
+    constant REG_TRIG_SBIT_HITMAP_VFAT3_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT3_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT3_LSB_ADDR    : std_logic_vector(7 downto 0) := x"b9";
+    constant REG_TRIG_SBIT_HITMAP_VFAT3_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT3_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT4_MSB_ADDR    : std_logic_vector(7 downto 0) := x"ba";
+    constant REG_TRIG_SBIT_HITMAP_VFAT4_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT4_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT4_LSB_ADDR    : std_logic_vector(7 downto 0) := x"bb";
+    constant REG_TRIG_SBIT_HITMAP_VFAT4_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT4_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT5_MSB_ADDR    : std_logic_vector(7 downto 0) := x"bc";
+    constant REG_TRIG_SBIT_HITMAP_VFAT5_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT5_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT5_LSB_ADDR    : std_logic_vector(7 downto 0) := x"bd";
+    constant REG_TRIG_SBIT_HITMAP_VFAT5_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT5_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT6_MSB_ADDR    : std_logic_vector(7 downto 0) := x"be";
+    constant REG_TRIG_SBIT_HITMAP_VFAT6_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT6_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT6_LSB_ADDR    : std_logic_vector(7 downto 0) := x"bf";
+    constant REG_TRIG_SBIT_HITMAP_VFAT6_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT6_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT7_MSB_ADDR    : std_logic_vector(7 downto 0) := x"c0";
+    constant REG_TRIG_SBIT_HITMAP_VFAT7_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT7_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT7_LSB_ADDR    : std_logic_vector(7 downto 0) := x"c1";
+    constant REG_TRIG_SBIT_HITMAP_VFAT7_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT7_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT8_MSB_ADDR    : std_logic_vector(7 downto 0) := x"c2";
+    constant REG_TRIG_SBIT_HITMAP_VFAT8_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT8_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT8_LSB_ADDR    : std_logic_vector(7 downto 0) := x"c3";
+    constant REG_TRIG_SBIT_HITMAP_VFAT8_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT8_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT9_MSB_ADDR    : std_logic_vector(7 downto 0) := x"c4";
+    constant REG_TRIG_SBIT_HITMAP_VFAT9_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT9_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT9_LSB_ADDR    : std_logic_vector(7 downto 0) := x"c5";
+    constant REG_TRIG_SBIT_HITMAP_VFAT9_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT9_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT10_MSB_ADDR    : std_logic_vector(7 downto 0) := x"c6";
+    constant REG_TRIG_SBIT_HITMAP_VFAT10_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT10_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT10_LSB_ADDR    : std_logic_vector(7 downto 0) := x"c7";
+    constant REG_TRIG_SBIT_HITMAP_VFAT10_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT10_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT11_MSB_ADDR    : std_logic_vector(7 downto 0) := x"c8";
+    constant REG_TRIG_SBIT_HITMAP_VFAT11_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT11_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT11_LSB_ADDR    : std_logic_vector(7 downto 0) := x"c9";
+    constant REG_TRIG_SBIT_HITMAP_VFAT11_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT11_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT12_MSB_ADDR    : std_logic_vector(7 downto 0) := x"ca";
+    constant REG_TRIG_SBIT_HITMAP_VFAT12_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT12_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT12_LSB_ADDR    : std_logic_vector(7 downto 0) := x"cb";
+    constant REG_TRIG_SBIT_HITMAP_VFAT12_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT12_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT13_MSB_ADDR    : std_logic_vector(7 downto 0) := x"cc";
+    constant REG_TRIG_SBIT_HITMAP_VFAT13_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT13_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT13_LSB_ADDR    : std_logic_vector(7 downto 0) := x"cd";
+    constant REG_TRIG_SBIT_HITMAP_VFAT13_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT13_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT14_MSB_ADDR    : std_logic_vector(7 downto 0) := x"ce";
+    constant REG_TRIG_SBIT_HITMAP_VFAT14_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT14_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT14_LSB_ADDR    : std_logic_vector(7 downto 0) := x"cf";
+    constant REG_TRIG_SBIT_HITMAP_VFAT14_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT14_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT15_MSB_ADDR    : std_logic_vector(7 downto 0) := x"d0";
+    constant REG_TRIG_SBIT_HITMAP_VFAT15_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT15_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT15_LSB_ADDR    : std_logic_vector(7 downto 0) := x"d1";
+    constant REG_TRIG_SBIT_HITMAP_VFAT15_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT15_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT16_MSB_ADDR    : std_logic_vector(7 downto 0) := x"d2";
+    constant REG_TRIG_SBIT_HITMAP_VFAT16_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT16_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT16_LSB_ADDR    : std_logic_vector(7 downto 0) := x"d3";
+    constant REG_TRIG_SBIT_HITMAP_VFAT16_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT16_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT17_MSB_ADDR    : std_logic_vector(7 downto 0) := x"d4";
+    constant REG_TRIG_SBIT_HITMAP_VFAT17_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT17_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT17_LSB_ADDR    : std_logic_vector(7 downto 0) := x"d5";
+    constant REG_TRIG_SBIT_HITMAP_VFAT17_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT17_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT18_MSB_ADDR    : std_logic_vector(7 downto 0) := x"d6";
+    constant REG_TRIG_SBIT_HITMAP_VFAT18_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT18_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT18_LSB_ADDR    : std_logic_vector(7 downto 0) := x"d7";
+    constant REG_TRIG_SBIT_HITMAP_VFAT18_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT18_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT19_MSB_ADDR    : std_logic_vector(7 downto 0) := x"d8";
+    constant REG_TRIG_SBIT_HITMAP_VFAT19_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT19_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT19_LSB_ADDR    : std_logic_vector(7 downto 0) := x"d9";
+    constant REG_TRIG_SBIT_HITMAP_VFAT19_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT19_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT20_MSB_ADDR    : std_logic_vector(7 downto 0) := x"da";
+    constant REG_TRIG_SBIT_HITMAP_VFAT20_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT20_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT20_LSB_ADDR    : std_logic_vector(7 downto 0) := x"db";
+    constant REG_TRIG_SBIT_HITMAP_VFAT20_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT20_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT21_MSB_ADDR    : std_logic_vector(7 downto 0) := x"dc";
+    constant REG_TRIG_SBIT_HITMAP_VFAT21_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT21_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT21_LSB_ADDR    : std_logic_vector(7 downto 0) := x"dd";
+    constant REG_TRIG_SBIT_HITMAP_VFAT21_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT21_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT22_MSB_ADDR    : std_logic_vector(7 downto 0) := x"de";
+    constant REG_TRIG_SBIT_HITMAP_VFAT22_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT22_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT22_LSB_ADDR    : std_logic_vector(7 downto 0) := x"df";
+    constant REG_TRIG_SBIT_HITMAP_VFAT22_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT22_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT23_MSB_ADDR    : std_logic_vector(7 downto 0) := x"e0";
+    constant REG_TRIG_SBIT_HITMAP_VFAT23_MSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT23_MSB_LSB     : integer := 0;
+
+    constant REG_TRIG_SBIT_HITMAP_VFAT23_LSB_ADDR    : std_logic_vector(7 downto 0) := x"e1";
+    constant REG_TRIG_SBIT_HITMAP_VFAT23_LSB_MSB    : integer := 31;
+    constant REG_TRIG_SBIT_HITMAP_VFAT23_LSB_LSB     : integer := 0;
+
+    constant REG_TRIG_CTRL_SBIT_SOT_INVALID_BITSKIP_ADDR    : std_logic_vector(7 downto 0) := x"e2";
+    constant REG_TRIG_CTRL_SBIT_SOT_INVALID_BITSKIP_MSB    : integer := 23;
+    constant REG_TRIG_CTRL_SBIT_SOT_INVALID_BITSKIP_LSB     : integer := 0;
 
 
     --============================================================================

--- a/src/trigger/sbits_hitmap.vhd
+++ b/src/trigger/sbits_hitmap.vhd
@@ -1,0 +1,100 @@
+----------------------------------------------------------------------------------
+-- CMS Muon Endcap
+-- GEM Collaboration
+-- Optohybrid v3 Firmware -- S-Bits hitmap
+-- L. Pétré
+----------------------------------------------------------------------------------
+-- Description:
+--   This module accumulates the full Sbits vector with minimal impact on PAR 
+--   thanks to the use of fanouts and pipelines
+----------------------------------------------------------------------------------
+-- 2019/07/18 -- Initial
+----------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_misc.all;
+use ieee.numeric_std.all;
+
+library work;
+use work.types_pkg.all;
+use work.trig_pkg.all;
+
+entity sbits_hitmap is
+
+    port(
+
+        clock_i    : in std_logic;
+        reset_i    : in std_logic;
+        acquire_i  : in std_logic;
+        sbits_i    : in sbits_array_t(MXVFATS-1 downto 0);
+        hitmap_o   : out sbits_array_t(MXVFATS-1 downto 0)
+
+    );
+
+end sbits_hitmap;
+
+architecture sbits_hitmap of sbits_hitmap is
+
+    -- Signal fanout (1 per IPBus register)
+    signal reset    : std_logic_vector(2*MXVFATS-1 downto 0);
+    signal acquire  : std_logic_vector(2*MXVFATS-1 downto 0);
+
+    -- Pipeline
+    signal sbits_s0 : sbits_array_t(MXVFATS-1 downto 0);
+    signal sbits_s1 : sbits_array_t(MXVFATS-1 downto 0);
+
+    signal hitmap   : sbits_array_t(MXVFATS-1 downto 0);
+
+    -- Attributes for no simplification logic
+    attribute equivalent_register_removal : string;
+    attribute equivalent_register_removal of reset : signal is "no";
+    attribute equivalent_register_removal of acquire : signal is "no";
+    attribute equivalent_register_removal of sbits_s0 : signal is "no";
+    attribute equivalent_register_removal of sbits_s1 : signal is "no";
+
+    attribute shreg_extract : string;
+    attribute shreg_extract of sbits_s0 : signal is "no";
+    attribute shreg_extract of sbits_s1 : signal is "no";
+
+begin
+
+    -- Fanout
+    process(clock_i)
+    begin
+        if rising_edge(clock_i) then
+            reset    <= (others => reset_i);
+            acquire  <= (others => acquire_i);
+        end if;
+    end process;
+
+    -- Pipeline
+    process(clock_i)
+    begin
+        if rising_edge(clock_i) then
+            sbits_s0 <= sbits_i;
+            sbits_s1 <= sbits_s0;
+        end if;
+    end process;
+
+    hitmap_g: for I in 0 to (MXVFATS - 1) generate
+    begin
+        process(clock_i)
+        begin
+            if rising_edge(clock_i) then
+                for J in 0 to 1 loop
+                    if reset(2*I+J) = '1' then
+                        hitmap(I)((J+1)*32-1 downto J*32) <= (others => '0');
+                    else
+                        if acquire(2*I+J) = '1' then
+                            hitmap(I)((J+1)*32-1 downto J*32) <= hitmap(I)((J+1)*32-1 downto J*32) or sbits_s1(I)((J+1)*32-1 downto J*32);
+                        end if;
+                    end if;
+                end loop;
+            end if;
+        end process;
+    end generate;
+
+    hitmap_o <= hitmap;
+
+end sbits_hitmap;

--- a/src/trigger/trig_alignment/frame_aligner.v
+++ b/src/trigger/trig_alignment/frame_aligner.v
@@ -25,7 +25,6 @@ module frame_aligner (
   input mask,
 
   input clock,
-  input clock4x,
 
   input [11:0] aligned_count_to_ready,
 

--- a/src/trigger/trig_alignment/trig_alignment.vhd
+++ b/src/trigger/trig_alignment/trig_alignment.vhd
@@ -48,15 +48,13 @@ port(
 
     sot_is_aligned         : out std_logic_vector (MXVFATS-1 downto 0);
     sot_unstable           : out std_logic_vector (MXVFATS-1 downto 0);
+    sot_invalid_bitskip    : out std_logic_vector (MXVFATS-1 downto 0);
 
     aligned_count_to_ready : in std_logic_vector (11 downto 0);
 
     clock                  : in std_logic;
-
-    clk80_0                : in std_logic;
     clk160_0               : in std_logic;
     clk160_90              : in std_logic;
-    clk160_180             : in std_logic;
 
     sbits                  : out std_logic_vector (( MXSBITS_CHAMBER - 1) downto 0)
 );
@@ -126,21 +124,21 @@ begin
             g_PHASE_SEL_EXTERNAL => FALSE
         )
         port map (
-            rst           => sot_reset(ivfat),
-            invert        => sot_invert (ivfat),
-            rxd_p         => start_of_frame_p(ivfat),
-            rxd_n         => start_of_frame_n(ivfat),
-            clk1x_logic   => clk80_0,
-            clk2x_logic   => clk160_0,
-            clk2x_0       => clk160_0,
-            clk2x_90      => clk160_90,
-            clk2x_180     => clk160_180,
-            rxdata_o      => start_of_frame_8b(ivfat),
-            tap_delay_i   => sot_tap_delay(ivfat),
-            e4_in         => (others => '0'),
-            e4_out        => vfat_e4(ivfat),
-            phase_sel_in  => (others => '0'),
-            phase_sel_out => vfat_phase_sel(ivfat)
+            clk1x_logic       => clock,
+            clk1x             => clock,
+            clk4x_0           => clk160_0,
+            clk4x_90          => clk160_90,
+            reset_i           => sot_reset(ivfat),
+            rxd_p             => start_of_frame_p(ivfat),
+            rxd_n             => start_of_frame_n(ivfat),
+            rxdata_o          => start_of_frame_8b(ivfat),
+            invert            => sot_invert (ivfat),
+            tap_delay_i       => sot_tap_delay(ivfat),
+            e4_in             => (others => '0'),
+            e4_out            => vfat_e4(ivfat),
+            phase_sel_in      => (others => '0'),
+            phase_sel_out     => vfat_phase_sel(ivfat),
+            invalid_bitskip_o => sot_invalid_bitskip(ivfat)
         );
 
     end generate;
@@ -162,21 +160,21 @@ begin
             g_PHASE_SEL_EXTERNAL => TRUE
         )
         port map (
-            rst           => tu_reset(ipin),
-            invert        => tu_invert (ipin),
-            rxd_p         => sbits_p(ipin),
-            rxd_n         => sbits_n(ipin),
-            clk1x_logic   => clk80_0,
-            clk2x_logic   => clk160_0,
-            clk2x_0       => clk160_0,
-            clk2x_90      => clk160_90,
-            clk2x_180     => clk160_180,
-            rxdata_o      => sbits_unaligned ((ipin+1)*8 - 1 downto ipin*8),
-            tap_delay_i   => trig_tap_delay(ipin),
-            e4_in         => vfat_e4(ipin/8),
-            e4_out        => open,
-            phase_sel_in  => vfat_phase_sel(ipin/8),
-            phase_sel_out => open
+            clk1x_logic       => clock,
+            clk1x             => clock,
+            clk4x_0           => clk160_0,
+            clk4x_90          => clk160_90,
+            reset_i           => tu_reset(ipin),
+            rxd_p             => sbits_p(ipin),
+            rxd_n             => sbits_n(ipin),
+            rxdata_o          => sbits_unaligned ((ipin+1)*8 - 1 downto ipin*8),
+            invert            => tu_invert (ipin),
+            tap_delay_i       => trig_tap_delay(ipin),
+            e4_in             => vfat_e4(ipin/8),
+            e4_out            => open,
+            phase_sel_in      => vfat_phase_sel(ipin/8),
+            phase_sel_out     => open,
+            invalid_bitskip_o => open
         );
 
     end generate;
@@ -201,7 +199,6 @@ begin
             start_of_frame => start_of_frame_8b(ivfat),
 
             clock          => clock,
-            clock4x        => clk160_0,
 
             aligned_count_to_ready => aligned_count_to_ready,
 

--- a/src/ucf/clocking.ucf
+++ b/src/ucf/clocking.ucf
@@ -2,11 +2,16 @@
 # Clock Periods
 #######################################################################################################################
 
-#NET "logic_clock_p" TNM_NET = "TN_LOGIC_CLOCK";
-#TIMESPEC TS_logic_clock = PERIOD "TN_LOGIC_CLOCK" 24.95 ns HIGH 50 %;
+# Main E-link clock
+NET "clock_p" TNM_NET = "TN_CLOCK";
+TIMESPEC TS_clock = PERIOD "TN_CLOCK" 3.09 ns HIGH 50 %;
 
-#NET "clock_p" TNM_NET = "TN_CLOCK";
-#TIMESPEC TS_clock = PERIOD "TN_CLOCK" 24.95 ns HIGH 50 %;
+## MGT reference clocks
+#NET "mgt_clk_p_i<0>" TNM_NET = "TN_MGT_CLK_0";
+#TIMESPEC TS_mgt_clk_0 = PERIOD "TN_MGT_CLK_0" 12.36 ns HIGH 50 %;
+
+NET "mgt_clk_p_i<1>" TNM_NET = "TN_MGT_CLK_1";
+TIMESPEC TS_mgt_clk_1 = PERIOD "TN_MGT_CLK_1" 12.36 ns HIGH 50 %;
 
 #######################################################################################################################
 # CFGMCLK
@@ -15,56 +20,21 @@
 NET "control/led_control_inst/async_clock" TNM_NET = "cfgmclk";
 TIMESPEC TS_cfgmclk = PERIOD "cfgmclk" 12.5 ns HIGH 50 %;
 
-TIMESPEC TS_clk_cfg_to_clk_logic = FROM "cfgmclk" TO "FFS" TIG;
-
+TIMESPEC TS_clk_cfg_to_clk_logic = FROM "cfgmclk" TO  FFS TIG ;
 
 ########################################################################################################################
-# GBT Deskew (Phase Shiftable) Clocks
+# E-link clock
 ########################################################################################################################
-
-#NET "logic_clock_p" IOSTANDARD = LVDS_25;
-#NET "logic_clock_p" DIFF_TERM = "FALSE";
-#NET "logic_clock_n" IOSTANDARD = LVDS_25;
-#NET "logic_clock_n" DIFF_TERM = "FALSE";
 
 NET "clock_p" IOSTANDARD = LVDS_25;
 NET "clock_p" DIFF_TERM = "FALSE";
 NET "clock_n" IOSTANDARD = LVDS_25;
 NET "clock_n" DIFF_TERM = "FALSE";
 
-### GBTx data clock -- these are 320MHz data clock (terminated outside), the phase is aligned such that rising edge is in the middle of the data bit
+## GBTx data clock
+## It is a 320MHz data clock (terminated outside), the phase is aligned such that rising edge is in the middle of the data bit
+NET "clock_p" LOC = J9; #elink clock
+NET "clock_n" LOC = H9; #elink clock
 
-NET "clock_p"   LOC = J9; #elink clock
-NET "clock_n"   LOC = H9; #elink clock
 #NET "clock_p"   LOC = A10; #dskw clock
 #NET "clock_n"   LOC = B10; #dskw clock
-
-########################################################################################################################
-# GBT
-########################################################################################################################
-
-# Output
-INST "elink_o_p" TNM = "elink_o_grp";
-INST "elink_o_n" TNM = "elink_o_grp";
-INST "gbt/gbt_serdes*/to_gbt_ser*/*" TNM = "elink_o_serdes_grp";
-
-TIMESPEC TS_ELINK_O_TIG = FROM "elink_o_serdes_grp" TO "elink_o_grp" TIG ;
-
-# Input
-INST "elink_i_p" TNM = "elink_i_grp";
-INST "elink_i_n" TNM = "elink_i_grp";
-INST "gbt/gbt_serdes*/*oversample/ise1*/*" TNM = "elink_i_serdes_grp";
-INST "gbt/gbt_serdes*/*oversample/dru/*data_in_delay*" TNM = "gbt_ff_grp";
-
-TIMESPEC TS_GBT_TIG = FROM "elink_i_serdes_grp" TO "gbt_ff_grp" TIG ;
-TIMESPEC TS_GBT_IOTIG = FROM "elink_i_grp" TO "elink_i_serdes_grp" TIG ;
-
-NET "gbt/gbt_serdes/gbt_oversample/q[6]" MAXDELAY = 2 ns;
-NET "gbt/gbt_serdes/gbt_oversample/q[7]" MAXDELAY = 2 ns;
-
-########################################################################################################################
-# Resync
-########################################################################################################################
-
-INST "*/s_resync_1"                             TNM = "resync_grp";
-TIMESPEC TS_SYNC = FROM "FFS" TO "resync_grp" TIG;

--- a/src/ucf/gbt.ucf
+++ b/src/ucf/gbt.ucf
@@ -13,14 +13,13 @@ TIMEGRP "gbt_status_grp" OFFSET = IN 12.5 ns VALID 25 ns BEFORE "clock_p" RISING
 ########################################################################################################################
 # E-links
 ########################################################################################################################
-# outputs
 
 # inputs
 # 320 MHz e-link
 # GBTx DIN 36
 NET "elink_i_p" IOSTANDARD = LVDS_25;
 NET "elink_i_p" DIFF_TERM = "FALSE";
-#
+
 NET "elink_i_n" IOSTANDARD = LVDS_25;
 NET "elink_i_n" DIFF_TERM = "FALSE";
 
@@ -29,3 +28,22 @@ NET "elink_o_n" LOC = L18;
 
 NET "elink_i_p" LOC = AD24;
 NET "elink_i_n" LOC = AE24;
+
+
+########################################################################################################################
+# GBT TIG
+########################################################################################################################
+
+# Output
+INST "elink_o_p" TNM = "elink_o_grp";
+INST "elink_o_n" TNM = "elink_o_grp";
+INST "gbt/gbt_serdes*/to_gbt_ser*/*" TNM = "elink_o_serdes_grp";
+
+TIMESPEC TS_ELINK_O_TIG = FROM "elink_o_serdes_grp" TO "elink_o_grp" TIG ;
+
+# Input
+INST "elink_i_p" TNM = "elink_i_grp";
+INST "elink_i_n" TNM = "elink_i_grp";
+INST "gbt/gbt_serdes*/*oversample/ise1*/*" TNM = "elink_i_serdes_grp";
+
+TIMESPEC TS_GBT_IOTIG = FROM "elink_i_grp" TO "elink_i_serdes_grp" TIG ;

--- a/src/ucf/misc_v3b.ucf
+++ b/src/ucf/misc_v3b.ucf
@@ -1,3 +1,11 @@
+
+########################################################################################################################
+# Resync
+########################################################################################################################
+
+INST "*/s_resync_1" TNM = "resync_grp";
+TIMESPEC TS_SYNC = FROM  FFS TO "resync_grp" TIG ;
+
 # This file constraints miscellaneous signals
 ## HDMI
 
@@ -107,3 +115,8 @@ NET "mgt_tx_n_o<3>" LOC = F2; #
 NET "adc_vp" LOC=U18;
 NET "adc_vn" LOC=V17;
 
+## Help P&R by placing the truncators
+INST "trigger/sbits/OH_FULL_GEN.cluster_packer_inst/u_first8/encloop[0].u_truncate/*" AREA_GROUP = "pblock_truncator_0";
+AREA_GROUP "pblock_truncator_0" RANGE=CLOCKREGION_X1Y2:CLOCKREGION_X1Y2;
+INST "trigger/sbits/OH_FULL_GEN.cluster_packer_inst/u_first8/encloop[1].u_truncate/*" AREA_GROUP = "pblock_truncator_1";
+AREA_GROUP "pblock_truncator_1" RANGE=CLOCKREGION_X0Y1:CLOCKREGION_X0Y1;

--- a/src/ucf/sbits.ucf
+++ b/src/ucf/sbits.ucf
@@ -3,18 +3,16 @@
 ################################################################################
 
 # S-bit TIG
-INST "trigger/sbits/trig_alignment/*oversample*/*ise1*/*"              TNM = sbit_serdes_grp;
-INST "trigger/sbits/trig_alignment/*oversample*/*dru*/*data_in_delay*" TNM = sbit_ff_grp;
-
 NET "vfat_sot_*"   TNM=sbit_i_grp;
 NET "vfat_sbits_*" TNM=sbit_i_grp;
 
-TIMESPEC TS_SBIT_IOTIG = FROM sbit_i_grp      TO sbit_serdes_grp TIG;
-TIMESPEC TS_SBIT_TIG   = FROM sbit_serdes_grp TO sbit_ff_grp     TIG;
+INST "trigger/sbits/trig_alignment/*oversample*/*ise1*/*" TNM = sbit_serdes_grp;
 
-NET "trigger/sbits/trig_alignment/*oversample*/q<*>" MAXDELAY = 2.00 ns;
+TIMESPEC TS_SBIT_IOTIG = FROM sbit_i_grp TO sbit_serdes_grp TIG;
+
 
 TIMEGRP "sbit_i_grp" OFFSET = IN 4 ns VALID 3.125 ns BEFORE "clock_p" RISING;
+
 
 NET vfat_sot_p<23>     IOSTANDARD=LVDS_25 | LOC = "AN19"; # polarity swap
 NET vfat_sot_n<23>     IOSTANDARD=LVDS_25 | LOC = "AN20"; # polarity swap
@@ -448,4 +446,3 @@ NET vfat_sbits_p<6>    IOSTANDARD=LVDS_25 | LOC = "AB28"; # polarity swap
 NET vfat_sbits_n<6>    IOSTANDARD=LVDS_25 | LOC = "AC28"; # polarity swap
 NET vfat_sbits_n<7>    IOSTANDARD=LVDS_25 | LOC = "AA31";
 NET vfat_sbits_p<7>    IOSTANDARD=LVDS_25 | LOC = "AA30";
-

--- a/src/utils/OVERSAMPLE.vhd
+++ b/src/utils/OVERSAMPLE.vhd
@@ -1,3 +1,5 @@
+-- TODO: fix reset for inverted pairs (outputs burst of 1's)
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
@@ -8,36 +10,40 @@ use unisim.vcomponents.all;
 entity oversample is
 generic (
   g_PHASE_SEL_EXTERNAL : boolean := FALSE;
-  g_BIT_WIDTH          : integer := 8;
   g_NUM_TAPS_45        : integer := 10
 );
 port(
-  invert         :  in std_logic := '0';
+  clk1x_logic    :  in std_logic;
+  clk1x          :  in std_logic;
+  clk4x_0        :  in std_logic;
+  clk4x_90       :  in std_logic;
+
+  reset_i        :  in std_logic;
+
   rxd_p          :  in std_logic;
   rxd_n          :  in std_logic;
-  clk1x_logic    :  in std_logic;
-  clk2x_logic    :  in std_logic;
-  clk2x_0        :  in std_logic;
-  clk2x_90       :  in std_logic;
-  clk2x_180      :  in std_logic;
-  rst            :  in std_logic;
+  rxdata_o       :  out std_logic_vector (7 downto 0);
+
+  invert         :  in std_logic := '0';
   tap_delay_i    :  in  std_logic_vector (4 downto 0) := "00000";
-  phase_sel_in   :  in  std_logic_vector (1 downto 0) := "00";
-  phase_sel_out  :  out std_logic_vector (1 downto 0);
+
   e4_in          :  in  std_logic_vector (3 downto 0) := "0000";
   e4_out         :  out std_logic_vector (3 downto 0);
-  rxdata_o       :  out std_logic_vector (g_BIT_WIDTH-1 downto 0)
+  phase_sel_in   :  in  std_logic_vector (1 downto 0) := "00";
+  phase_sel_out  :  out std_logic_vector (1 downto 0);
+
+  invalid_bitskip_o : out std_logic
 );
 end oversample;
 
 architecture behavioral of oversample is
 
-  signal reset         : std_logic;
+  signal reset_serdes  : std_logic;
+  signal reset_output  : std_logic_vector(3 downto 0);
   signal data_p,data_n : std_logic;
-  signal q             : std_logic_vector(g_BIT_WIDTH-1 downto 0);
-  signal rxdata        : std_logic_vector(g_BIT_WIDTH-1 downto 0):=(others=>'0');
-  signal rxdata_inv    : std_logic_vector(g_BIT_WIDTH-1 downto 0):=(others=>'0');
-  signal rxce          : std_logic:='0';
+  signal q             : std_logic_vector(7 downto 0);
+  signal rxdata        : std_logic_vector(7 downto 0):=(others=>'0');
+  signal rxdata_inv    : std_logic_vector(7 downto 0):=(others=>'0');
   signal data          : std_logic_vector(1 downto 0);
   signal tap_delay     : std_logic_vector (tap_delay_i'high downto 0);
   signal tap_delay_0   : std_logic_vector (tap_delay_i'high downto 0);
@@ -46,20 +52,27 @@ architecture behavioral of oversample is
   attribute ASYNC_REG  : string;
   attribute ASYNC_REG  of tap_delay : signal is "TRUE";
 
-  -- keep q for timing constraint
-  attribute MARK_DEBUG : string;
-  attribute MARK_DEBUG of q : signal is "true";
-
 begin
 
   ----------------------------------------------------------------------------------------------------------------------
   -- Reset
   ----------------------------------------------------------------------------------------------------------------------
 
-  process(clk2x_0)
+  process(clk4x_0)
   begin
-    if rising_edge(clk2x_0) then
-      reset <= rst;
+    if rising_edge(clk4x_0) then
+      reset_serdes <= reset_i;
+    end if;
+  end process;
+
+  process(clk1x)
+  begin
+    if rising_edge(clk1x) then
+      if reset_i = '1' then
+        reset_output <= (others => '1');
+      else
+        reset_output <= reset_output(reset_output'high-1 downto reset_output'low) & '0';
+      end if;
     end if;
   end process;
 
@@ -72,7 +85,7 @@ begin
     if rising_edge(clk1x_logic) then
       tap_delay    <= tap_delay_i;
       tap_delay_0  <= tap_delay ;
-      tap_delay_45 <= std_logic_vector (unsigned(tap_delay)  + to_unsigned(g_NUM_TAPS_45,tap_delay'length));
+      tap_delay_45 <= std_logic_vector (unsigned(tap_delay) + to_unsigned(g_NUM_TAPS_45,tap_delay'length));
     end if;
   end process;
 
@@ -80,23 +93,23 @@ begin
   -- IBUFDS
   ----------------------------------------------------------------------------------------------------------------------
 
-  rx_ibuf_d:ibufds_diff_out
+  rx_ibuf_d: ibufds_diff_out
   generic map(
           IBUF_LOW_PWR => TRUE,
           DIFF_TERM    => TRUE,
           IOSTANDARD   => "LVDS_25")
   port map(
-          i=>rxd_p,
-          ib=>rxd_n,
-          o=>data_p,
-          ob=>data_n
+          i  => rxd_p,
+          ib => rxd_n,
+          o  => data_p,
+          ob => data_n
   );
 
   ----------------------------------------------------------------------------------------------------------------------
   -- IODELAY in FPGA agnostic wrapper
   ----------------------------------------------------------------------------------------------------------------------
 
-  delay_master : entity work.iodelay
+  delay_master: entity work.iodelay
   port map(
           clock       => clk1x_logic,
           tap_delay_i => tap_delay_0,
@@ -104,7 +117,7 @@ begin
           data_o      => data(0)
   );
 
-  delay_slave  : entity work.iodelay
+  delay_slave: entity work.iodelay
   port map(
           clock       => clk1x_logic,
           tap_delay_i => tap_delay_45,
@@ -118,10 +131,9 @@ begin
 
   ise1_m: entity work.iserdes
   port map(
-          reset_i   => reset,
-          clk2x_0   => clk2x_0,
-          clk2x_180 => clk2x_180,
-          clk2x_90  => clk2x_90,
+          clk_i     => clk4x_0,
+          clk_90_i  => clk4x_90,
+          reset_i   => reset_serdes,
           data_i    => data(0),
           data_o(0) => q(1),
           data_o(1) => q(5),
@@ -131,10 +143,9 @@ begin
 
   ise1_s: entity work.iserdes
   port map(
-          reset_i   => reset,
-          clk2x_0   => clk2x_0,
-          clk2x_180 => clk2x_180,
-          clk2x_90  => clk2x_90,
+          clk_i     => clk4x_0,
+          clk_90_i  => clk4x_90,
+          reset_i   => reset_serdes,
           data_i    => data(1),
           data_o(0) => q(0),
           data_o(1) => q(4),
@@ -151,19 +162,22 @@ begin
     g_PHASE_SEL_EXTERNAL => g_PHASE_SEL_EXTERNAL
   )
   port map(
+          clk1x         => clk1x,
+          clk4x         => clk4x_0,
+
           i             => q,             -- the even bits are inverted!
-          clk1x         => clk1x_logic,   --
-          clk2x         => clk2x_logic,   --
-          phase_sel_in  => phase_sel_in,  --
-          phase_sel_out => phase_sel_out, --
-          e4_in         => e4_in,  --
-          e4_out        => e4_out, --
           o             => rxdata,        -- 8-bit deserialized data
-          vo            => rxce           -- rx valid
+
+          e4_in         => e4_in,
+          e4_out        => e4_out,
+          phase_sel_in  => phase_sel_in,
+          phase_sel_out => phase_sel_out,
+
+          invalid_bitskip_o => invalid_bitskip_o
   );
 
   rxdata_inv <= rxdata when invert='0' else not rxdata;
 
-  rxdata_o <= (others => '0') when reset='1' else rxdata_inv (g_BIT_WIDTH-1 downto 0);
+  rxdata_o <= (others => '0') when reset_output(reset_output'high)='1' else rxdata_inv(7 downto 0);
 
 end behavioral;

--- a/src/utils/iserdes.vhd
+++ b/src/utils/iserdes.vhd
@@ -11,25 +11,31 @@ use work.param_pkg.all;
 
 entity iserdes is
 generic (
-g_SERDES_MODE : string := "MASTER"
+  g_SERDES_MODE : string := "MASTER"
 );
 port(
-  data_i        : in std_logic;
+  clk_i         : in std_logic;
+  clk_90_i      : in std_logic;
   reset_i       : in std_logic;
-  data_o        : out std_logic_vector (3 downto 0);
-  clk2x_0       : in std_logic;
-  clk2x_180     : in std_logic;
-  clk2x_90      : in std_logic
+  data_i        : in std_logic;
+  data_o        : out std_logic_vector (3 downto 0)
 );
 end iserdes;
 
 architecture behavioral of iserdes is
 
-  signal clk2x_270 : std_logic;
+  signal clk     : std_logic;
+  signal clk_90  : std_logic;
+  signal clk_180 : std_logic;
+  signal clk_270 : std_logic;
 
 begin
 
-  clk2x_270 <= not clk2x_90;
+  -- Clocks MUST come from only two BFUG/BUFIO; see UG471
+  clk     <= clk_i;
+  clk_90  <= clk_90_i;
+  clk_180 <= not clk_i;
+  clk_270 <= not clk_90_i;
 
   ----------------------------------------------------------------------------------------------------------------------
   -- iserdes
@@ -47,9 +53,9 @@ begin
           SERDES_MODE    => g_SERDES_MODE,
           IOBDELAY       => "IFD")
   port map(
-          clk          => clk2x_0,
-          clkb         => clk2x_180,
-          oclk         => clk2x_90,
+          clk          => clk,
+          clkb         => clk_180,
+          oclk         => clk_90,
           d            => '0',
           bitslip      => '0',
           ce1          => '1',
@@ -116,10 +122,10 @@ begin
 
           -- clocks
           clkdivp => '0',       -- 1-bit input: tbd
-          clk     => clk2x_0,   -- 1-bit input: high-speed clock
-          clkb    => clk2x_180, -- 1-bit input: high-speed secondary clock
-          oclk    => clk2x_90,  -- 1-bit input: high speed output clock used when interface_type="memory"
-          oclkb   => clk2x_270, -- 1-bit input: high speed negative edge output clock
+          clk     => clk,       -- 1-bit input: high-speed clock
+          clkb    => clk_180,   -- 1-bit input: high-speed secondary clock
+          oclk    => clk_90,    -- 1-bit input: high speed output clock used when interface_type="memory"
+          oclkb   => clk_270,   -- 1-bit input: high speed negative edge output clock
           clkdiv  => '0',       -- 1-bit input: divided clock
 
           -- dynamic clock inversions: 1-bit each input: dynamic clock inversion pins to switch clock polarity

--- a/tools/oh_settings.py
+++ b/tools/oh_settings.py
@@ -5,10 +5,10 @@ now = datetime.datetime.now()
 gem_version = "ge11"
 oh_version  = "v3c"
 geb_version = "v3c"
-geb_length  = "long"
+geb_length  = "short"
 firmware_version_major   = "03"
 firmware_version_minor   = "02"
-firmware_release_version = "05"
+firmware_release_version = "06"
 # END: OH_VERSION
 
 hybrid_version           = "v3b"

--- a/tools/update_vfat_counters.py
+++ b/tools/update_vfat_counters.py
@@ -22,9 +22,9 @@ def main():
     MARKER_END="<!-- END: VFAT_MASK DO NOT EDIT -->"
     insert_code (ADDRESS_TABLE_TOP, ADDRESS_TABLE_TOP, MARKER_START, MARKER_END, write_vfat_mask)
 
-    MARKER_START='<!-- START: SOT_READY_UNSTABLE DO NOT EDIT -->'
-    MARKER_END="<!-- END: SOT_READY_UNSTABLE DO NOT EDIT -->"
-    insert_code (ADDRESS_TABLE_TOP, ADDRESS_TABLE_TOP, MARKER_START, MARKER_END, write_ready_unstable)
+    MARKER_START='<!-- START: SOT_STATUS DO NOT EDIT -->'
+    MARKER_END="<!-- END: SOT_STATUS DO NOT EDIT -->"
+    insert_code (ADDRESS_TABLE_TOP, ADDRESS_TABLE_TOP, MARKER_START, MARKER_END, write_status)
 
     MARKER_START='<!-- START: ACTIVE_VFATS DO NOT EDIT -->'
     MARKER_END="<!-- END: ACTIVE_VFATS DO NOT EDIT -->"
@@ -113,7 +113,7 @@ def write_active_vfats (file_handle):
     f.write('%s    mask="%s"\n' % (padding, mask))
     f.write('%s    fw_signal="active_vfats"/>\n' % (padding))
 
-def write_ready_unstable (file_handle):
+def write_status (file_handle):
 
     f = file_handle
     padding = "            " #spaces for indentation
@@ -132,6 +132,11 @@ def write_ready_unstable (file_handle):
     f.write('%s    description="%d bit list of VFATs with unstable Start-of-frame pulses (became misaligned after already achieving lock)"\n'  %  (padding, num_vfats))
     f.write('%s    mask="%s"\n'                                                                                                                %  (padding, mask))
     f.write('%s    fw_signal="sot_unstable" />\n'                                                                                              %  (padding))
+
+    f.write('%s<node id="SBIT_SOT_INVALID_BITSKIP" address="0xe2" permission="r"\n'                                 %  (padding))
+    f.write('%s    description="%d bit list of VFATs with a invalid bitskip counter for Start-of-frame pulses"\n'  %  (padding, num_vfats))
+    f.write('%s    mask="%s"\n'                                                                                    %  (padding, mask))
+    f.write('%s    fw_signal="sot_invalid_bitskip" />\n'                                                           %  (padding))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR aims at fixing issues encountered during GEM chamber QC operations:

* It restores the timing constraints for the external clocks in order to fix the Sbit clustering bug, but potentially many more to come.
* It adds a Sbit hitmap which helps at debugging the Sbits differential pairs, but should also help at finding the proper Sbit delays (I'm convinced that it is possible to complete a full Sbit delays scan in more or less 30 minutes).
* It fixes the unstable SOT encountered for some SOT tap delays. Solving this bug also removes the need for a 80MHz clock.

Here are more details about the last bug. The oversampling DRU as described in the Xilinx application note is designed to work with different clock frequencies for the source and the destination. Therefore it cannot assume a 8 bits/BX output, but uses a valid output signal.

The issue arises with the positive and negative bitskip operations which can happen at any time if the sampling phase switches between "00" and "10" and which causes data corruption if great care is not taken.

The fix uses the fact that the system is fully synchronous. Therefore it is always possible to output 8 bits/BX. The 1, 2 or 3 bits of oversampled data is fed into a 12 bits shift-register depending on the bitskip status. At the same time the absolute number of bitskips is counted and used as bitslip. In theory a shift register of 10 bits should be enough (every positive bitskip is compensated with a negative bitskip; and the opposite is true as well), but 2 more bits are added for safety.

The design shows good behavior on ULB test stand with hours without unstable SOT (the SOT of some VFATs was unstable after only a few seconds in the previous releases). Moreover the Sbits data shows the expected behavior in terms of "Sbit rate vs threshold" and tap delays.

This PR does **not** fix issues regarding the oversampling reset scheme which was already broken and causes unexpected behavior on status registers or data quality. I'll work on that when I'm back from holidays.

The PR does not fix the trigger link initialization issue either. It will require much more investigations and probably help from Xilinx.